### PR TITLE
Fixes for `./bin/pkt-stack pokt-net dev up`

### DIFF
--- a/bin/pkt-stack
+++ b/bin/pkt-stack
@@ -12,6 +12,7 @@ source .env
 case $STACK in
   "pokt-net")
     echo "Spinning $ACTION $STACK $ENV stack..."
+    CWD=$(pwd) \
     TAG=$POCKET_RELEASE_TAG \
     SPECIFIC_NODE=$SPECIFIC_NODE \
     make -f $(pwd)/Makefile pokt-net-$ENV-$ACTION;

--- a/docker/pokt-net/dev-tm/watch.sh
+++ b/docker/pokt-net/dev-tm/watch.sh
@@ -18,7 +18,6 @@ then
   exit 1;
 fi
 
-
 DEBUG_COMMAND() {
   $POCKET_ROOT/prepare-tendermint.sh;
   cd $POCKET_PATH;
@@ -34,7 +33,9 @@ DEBUG_COMMAND() {
     --headless \
     --accept-multiclient \
     --listen=:$DEBUG_PORT \
-    --api-version=2 -- $EXECCOMMAND
+    --api-version=2 \
+    -- \
+    $EXECCOMMAND
 }
 
 NO_DEBUG_COMMAND() {

--- a/docker/pokt-net/dev/watch.sh
+++ b/docker/pokt-net/dev/watch.sh
@@ -1,8 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Starting watch.sh..."
 
-echo "POCKET_CORE_KEY: $POCKET_CORE_KEY, POCKET_CORE_SEEDS: $POCKET_CORE_SEEDS, POCKET_CORE_PUBLIC_KEY: $POCKET_CORE_PUBLIK_KEY";
+echo "POCKET_CORE_KEY: ${POCKET_CORE_KEY}";
+echo "POCKET_CORE_SEEDS: ${POCKET_CORE_SEEDS}";
+echo "POCKET_CORE_PUBLIC_KEY: ${POCKET_CORE_PUBLIK_KEY}";
 
 if [ -z $EXECOMMAND ]
 then
@@ -19,17 +21,49 @@ then
   exit 1;
 fi
 
-command=''
+
+DEBUG_COMMAND() {
+  echo 'starting pocket with dlv...';
+
+  cd ${POCKET_PATH};
+
+  dlv_file_name="ouput_${POCKET_ADDRESS}.dlv";
+  touch ${dlv_file_name};
+
+  dlv debug ${POCKET_PATH}/app/cmd/pocket_core/main.go \
+    --continue \
+    --output ${dlv_file_name} \
+    --headless \
+    --accept-multiclient \
+    --listen=:${DEBUG_PORT} \
+    --api-version=2 \
+    -- \
+    ${EXECCOMMAND}
+}
+
+NO_DEBUG_COMMAND() {
+  echo 'starting pocket without dlv...';
+
+  cd ${POCKET_PATH};
+
+  go run ${POCKET_PATH}/app/cmd/pocket_core/main.go ${EXECCOMMAND}
+}
+
+export -f DEBUG_COMMAND
+export -f NO_DEBUG_COMMAND
+
+command=""
 if [ $DEBUG==1 ];
 then
-  command="touch output.dlv && dlv debug $POCKET_PATH/app/cmd/pocket_core/main.go --continue --output output.dlv --headless --accept-multiclient --listen=:$DEBUG_PORT --api-version=2 -- $EXECCOMMAND"
+  command="DEBUG_COMMAND"
 else
-  command="go run $POCKET_PATH/app/cmd/pocket_core/main.go $EXECCOMMAND"
+  command="NO_DEBUG_COMMAND"
 fi;
 
-echo $command
+echo "About to run the following command with reflex: $command"
+
+cd $POCKET_ROOT
 reflex \
   --start-service \
-  -r '\.go' \
-  -s -- sh -c $command;
-
+  -r '\.go$' \
+  -s -- /bin/bash -c "$command";

--- a/stacks/pokt-net/dev/stack.yml
+++ b/stacks/pokt-net/dev/stack.yml
@@ -94,3 +94,4 @@ services:
 networks:
   poktnet:
     driver: overlay
+    attachable: true


### PR DESCRIPTION
Recent changes in pocket-e2e-stack cause the startup command
above to fail. This change includes several minor script fixes
& updates to make it functional again.

Shell #1 (host machine): `./bin/pkt-stack pokt-net dev up`
Shell #2 (host machine): `curl -X POST localhost:8082/v1/query/height`